### PR TITLE
Update to latest rmw_zenoh: 0.2.5 on Jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 <sub>Built by the <a href="https://zenoh.io">Zenoh</a> team at <a href="https://www.zettascale.tech">ZettaScale</a> with ❤️</sub>
 </div>
 
+> [!NOTE]
+> ***Last Updated: August 2025***
+> *This repository has been updated to use the latest version of `rmw_zenoh` (0.2.5 on Jazzy)*
+
 ## About
 
 Welcome! This repository is part of the `Demystifying ROS 2 Networking` workshop, scheduled to take place on October 21st at ROSCon 2024. It contains all the resources you’ll need to get started with `rmw_zenoh`, the Zenoh middleware for `ROS 2`.
@@ -47,15 +51,13 @@ Alternatively, you can clone this repository and build the image yourself using 
 ./docker/build_image.sh
 ```
 
-The image includes ROS 2 Jazzy Jalisco (core) with pre-installed demo ROS 2 packages. It also has a workspace at `/ros_ws` where `rmw_zenoh` is already built and installed from source. Both the ROS 2 Jazzy environment and the workspace will be automatically set up when you start a bash session (see the `/root/.bashrc` file for details).
+The image includes ROS 2 Jazzy Jalisco (core) with pre-installed `rmw_zenoh_cpp` and other demo ROS 2 packages. Both the ROS 2 Jazzy environment and the workspace will be automatically set up when you start a bash session (see the `/root/.bashrc` file for details).
 
 ### Using the Docker Container
 
 The docker directory contains several scripts to help manage the container:
 
 * Run [`./docker/create_container.sh`](docker/create_container.sh) to create a container named `roscon2024_workshop`, or use the `$CONTAINER_NAME` environment variable to specify a custom name. The container will use the host network (`--net host`). Important directories in the container include:
-  * `/ros_ws`: The ROS workspace
-  * `/ros_ws/src/rmw_zenoh`: The `rmw_zenoh` source code (already built and installed in the workspace)
   * `/ros_ws/zenoh_confs`: A volume mapped to the `zenoh_confs/` directory in this repository
 * Run [`./docker/login_container.sh`](docker/login_container.sh) to start a bash shell inside the container
 * Run [`./docker/restart_container.sh`](docker/restart_container.sh) to restart the container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,14 +16,13 @@ ARG RMW_ZENOH_BRANCH=jazzy
 
 ARG BASE_IMAGE=ros:${ROS_DISTRO}-ros-core
 
-FROM ${BASE_IMAGE} AS ros_base
+FROM ${BASE_IMAGE}
 
-# Install required packages to build rmw_zenoh, some demos/tutos for the workshop
+# Install rmw_zenoh, some demos/tutos for the workshop
 # and some usefull tools (vim, ping...)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-rmw-zenoh-cpp \
     ros-${ROS_DISTRO}-ament-cmake-vendor-package \
-    cargo \
-    clang \
     ros-dev-tools \
     ros-${ROS_DISTRO}-tracetools \
     ros-${ROS_DISTRO}-demo-nodes-cpp \
@@ -37,26 +36,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /ros_ws
-
-FROM ros_base AS build
-
-ARG ROS_DISTRO
-ARG RMW_ZENOH_BRANCH
-
-RUN mkdir -p src && \
-    cd src && \
-    git clone https://github.com/ros2/rmw_zenoh.git -b $RMW_ZENOH_BRANCH && \
-    cd .. && \
-    . /opt/ros/${ROS_DISTRO}/setup.sh && \
-    rosdep init && rosdep update && \
-    rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y && \
-    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
-
-FROM ros_base
-
-COPY --from=build /ros_ws/src /ros_ws/src
-COPY --from=build /ros_ws/install /ros_ws/install
 COPY rmw_zenoh_env.bash /
 
 # Make /root/.bashrc to load /rmw_zenoh_env.bash for `docker exec` commands to have proper env

--- a/docker/create_container.sh
+++ b/docker/create_container.sh
@@ -26,8 +26,8 @@ else
             --name "$CONTAINER_NAME" \
             -v "$BASE_DIR/zenoh_confs:/ros_ws/zenoh_confs" \
             -e DISPLAY=host.docker.internal:0 \
-            -p $EXPOSED_PORT:$EXPOSED_PORT/tcp \
-            -p $EXPOSED_PORT:$EXPOSED_PORT/udp \
+            -p "$EXPOSED_PORT:$EXPOSED_PORT/tcp" \
+            -p "$EXPOSED_PORT:$EXPOSED_PORT/udp" \
             "$IMAGE"
     else
          docker run -it --init -d \

--- a/docker/rmw_zenoh_env.bash
+++ b/docker/rmw_zenoh_env.bash
@@ -1,7 +1,5 @@
 # setup ROS environment
 source "/opt/ros/$ROS_DISTRO/setup.bash" --
-# setup rmw_zenoh environment
-source /ros_ws/install/setup.bash
 export RMW_IMPLEMENTATION=rmw_zenoh_cpp
 # set other useful variables
 export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"

--- a/exercises/ex-5.md
+++ b/exercises/ex-5.md
@@ -41,7 +41,7 @@ Edit your `zenoh_confs/ROUTER_CONFIG.json5` again to:
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on UDP multicast.
       /// Accepts a single value or different values for router, peer and client.
       /// Each value is bit-or-like combinations of "peer", "router" and "client".
-      autoconnect: { router: "router" },
+      autoconnect: { router: ["router"] },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
    },
@@ -79,6 +79,8 @@ Try running `rmw_zenoh` Nodes without any router in 2 different configurations:
   ```
 
 * Then run:
+  * `ros2 daemon stop`
+    *This is to make sure a daemon is not running with a wrong configuration (without multicast), impacting `ros2 topic echo` command.*
   * `ZENOH_SESSION_CONFIG_URI=/ros_ws/zenoh_confs/SESSION_CONFIG.json5 ros2 topic pub /chatter std_msgs/msg/String "data: Hello from <YOUR_NAME>"`
   * `ZENOH_SESSION_CONFIG_URI=/ros_ws/zenoh_confs/SESSION_CONFIG.json5 ros2 topic echo /chatter`
 
@@ -103,6 +105,7 @@ With previous configuration the Nodes on different hosts didn't discover each ot
 
   Here `[::]` means any IPv6 or IPv4 interface, and `0` means the OS will choose an available port number.
 * Then run:
+  * `ros2 daemon stop`
   * `ZENOH_SESSION_CONFIG_URI=/ros_ws/zenoh_confs/SESSION_CONFIG.json5 ros2 topic pub /chatter std_msgs/msg/String "data: Hello from <YOUR_NAME>"`
   * `ZENOH_SESSION_CONFIG_URI=/ros_ws/zenoh_confs/SESSION_CONFIG.json5 ros2 topic echo /chatter`
 

--- a/exercises/ex-6.md
+++ b/exercises/ex-6.md
@@ -34,14 +34,18 @@ Then in container A:
         {
           // Rule identifier
           id: "my_rule",
-          // Deny publications ("put" Zenoh operation) in egress on WiFi interface for a Zenoh key expression
+          // Deny publications ("put" messages, and "declare_queryable" + "reply" in case of TRANSIENT_LOCAL publisher)
+          // in egress direction on WiFi interface for the Zenoh key expressions used by the "/chatter" topic
           permission: "deny",
-          messages: [ "put" ],
+          messages: [ "put", "declare_queryable", "reply" ],
           flows:["egress"],
           key_exprs: [
             // The Zenoh key expression used for the "/chatter" topic
             //"0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18"
-            "*/chatter/**"
+            "*/chatter/*/*",
+            // The Zenoh key expression used for TRANSIENT_LOCAL behaviout of "/chatter" topic
+            //"0/chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18/@adv/sub/18bf4236bf6b467ee3ec28d43d182289/15/_"
+            "*/chatter/*/*/@adv/sub/*/*/_"
           ],
         },
       ],
@@ -72,7 +76,7 @@ Now, run the following commands in each container:
 * In container A:
   * Start the router (with the custom configuration): `ZENOH_ROUTER_CONFIG_URI=/ros_ws/zenoh_confs/ROUTER_CONFIG.json5 ros2 run rmw_zenoh_cpp rmw_zenohd`
     You can also add this environment variable to see the router applying the access control:
-    `RUST_LOG=info,zenoh::net::routing::interceptor=debug`
+    `RUST_LOG=info,zenoh::net::routing::interceptor=trace`
   * Start the publisher on the denied topic:
     `ros2 topic pub /chatter std_msgs/msg/String "data: Hello just me!"`
   * Start another publisher on an allowed topic:

--- a/exercises/ex-7.md
+++ b/exercises/ex-7.md
@@ -13,14 +13,16 @@ In container A add this `downsampling` configuration at the end of your `zenoh_c
 ```json5
 downsampling: [
   {
-    // Downsampling publications in egress on WiFi interface
+    // Downsampling publications ("push" messages, and "reply" in case of TRANSIENT_LOCAL publisher)
+    // in egress direction on WiFi interface
+    messages: ["push", "reply"],
+    flows: ["egress"],
     interfaces: ["<YOUR_WIFI_INTERFACE>"],
-    flow: "egress",
     rules: [
-      // 0.5Hz for the Zenoh key expression used for the "/chatter_public" topic
+      // 0.6Hz for the Zenoh key expression used for the "/chatter_public" topic
       {
         key_expr: "*/chatter_public/**",
-        freq: 0.5
+        freq: 0.6
       },
     ],
   },
@@ -34,7 +36,7 @@ Run the same commands than for previous exercise:
 * In container A:
   * Start the router (with the custom configuration): `ZENOH_ROUTER_CONFIG_URI=/ros_ws/zenoh_confs/ROUTER_CONFIG.json5 ros2 run rmw_zenoh_cpp rmw_zenohd`
     You can also add this environment variable to see the router applying the access control:
-    `RUST_LOG=info,zenoh::net::routing::interceptor=debug`
+    `RUST_LOG=info,zenoh::net::routing::interceptor=trace`
   * Start the publisher on the denied topic:
     `ros2 topic pub /chatter std_msgs/msg/String "data: Hello just me!"`
   * Start another publisher on an allowed topic:


### PR DESCRIPTION
Update to latest `rmw_zenoh_cpp` package from official ROS 2 repository (0.2.5 on Jazzy).
Update some configurations and exercise descriptions accordingly.